### PR TITLE
Update the tauri link

### DIFF
--- a/src/model/modules/01-framework.ts
+++ b/src/model/modules/01-framework.ts
@@ -162,7 +162,7 @@ export default <AppItem[]> [{
   keywords: ['ionic'],
   name: 'Ionic',
 }, {
-  homepage: 'https://tauri.studio/',
+  homepage: 'https://tauri.app/',
   repository: 'https://github.com/tauri-apps/tauri',
   icon: 'tauri.png',
   keywords: ['tauri'],


### PR DESCRIPTION
The original link `https://tauri.studio/` is not properly accessible, updated to `https://tauri.app/`.

![image](https://github.com/hello-nav/hello-nav/assets/45645138/d9ef00d2-4def-4d7e-9071-c828c7094253)
